### PR TITLE
reissue access token via refresh token

### DIFF
--- a/authentication/backends.py
+++ b/authentication/backends.py
@@ -1,24 +1,30 @@
 from rest_framework_simplejwt.authentication import JWTAuthentication
-from rest_framework.exceptions import AuthenticationFailed
 from rest_framework_simplejwt.exceptions import InvalidToken, TokenError
+from rest_framework.exceptions import AuthenticationFailed
 
 class CookieJWTAuthentication(JWTAuthentication):
     def authenticate(self, request):
-        access_token = request.COOKIES.get('access_token')
+        access_token = request.COOKIES.get("access_token")
 
         if not access_token:
-            return None
+            return None  # 토큰 없음
 
         try:
             validated_token = self.get_validated_token(access_token)
-            user = self.get_user(validated_token)
         except InvalidToken as e:
-            raise AuthenticationFailed("Invalid token.")
-        except TokenError as e:
-            raise AuthenticationFailed("Token error: " + str(e))
-        except Exception as e:
-            raise AuthenticationFailed(str(e))
+            # InvalidToken의 상세 메시지 분석
+            error_detail = getattr(e, "detail", None)
+            if error_detail and isinstance(error_detail, dict):
+                messages = error_detail.get("messages", [])
+                for msg in messages:
+                    # 만료된 토큰인지 확인
+                    if "만료된" in str(msg.get("message", "")) or "expired" in str(msg.get("message", "")):
+                        raise AuthenticationFailed("Access token has expired.")  # 만료 메시지 반환
+            raise AuthenticationFailed("Invalid token.")  # 기본 메시지
+        except TokenError:
+            raise AuthenticationFailed("Token error.")  # 기타 토큰 에러
 
+        user = self.get_user(validated_token)
         if user is None or not user.is_active:
             raise AuthenticationFailed("User is inactive.")
 

--- a/authentication/backends.py
+++ b/authentication/backends.py
@@ -12,10 +12,14 @@ class CookieJWTAuthentication(JWTAuthentication):
         try:
             validated_token = self.get_validated_token(access_token)
             user = self.get_user(validated_token)
-        except (InvalidToken, AuthenticationFailed, TokenError):
-            return None
+        except InvalidToken as e:
+            raise AuthenticationFailed("Invalid token.")
+        except TokenError as e:
+            raise AuthenticationFailed("Token error: " + str(e))
+        except Exception as e:
+            raise AuthenticationFailed(str(e))
 
         if user is None or not user.is_active:
-            return None
+            raise AuthenticationFailed("User is inactive.")
 
         return (user, validated_token)

--- a/authentication/urls.py
+++ b/authentication/urls.py
@@ -1,5 +1,3 @@
-# boards/urls.py
-
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
 from .views import *

--- a/boards/urls.py
+++ b/boards/urls.py
@@ -1,5 +1,3 @@
-# boards/urls.py
-
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
 from .views import PostViewSet, CommentViewSet

--- a/templates/base.html
+++ b/templates/base.html
@@ -53,6 +53,52 @@
             <p>© 2024 UPSIGHT 게시판</p>
         </footer>
         <!-- JavaScript -->
+        <script>
+            async function refreshAccessToken() {
+                try {
+                    // Refresh token 요청
+                    const response = await fetch("{% url 'token_refresh' %}", {
+                        method: "POST",
+                        credentials: "include", // Refresh token이 HttpOnly 쿠키에 저장된 경우 필요
+                        headers: {
+                            "Content-Type": "application/json",
+                        },
+                        body: JSON.stringify({}),
+                    });
+
+                    if (response.ok) {
+                        console.log("Access token successfully refreshed.");
+                        // Access token 재발급 성공 시, 새로고침
+                        {% comment %} window.location.reload(); {% endcomment %}
+                    } else {
+                        console.error("Failed to refresh access token.");
+                        // 재발급 실패 시 로그아웃으로 이동
+                        {% comment %} window.location.href = "{% url 'authentication:login' %}"; {% endcomment %}
+                    }
+                } catch (error) {
+                    console.error("Error during token refresh:", error);
+                    window.location.href = "{% url 'authentication:login' %}";
+                }
+            }
+
+            // 전역적으로 fetch API를 확장하여 에러를 감지하고 처리
+            const originalFetch = window.fetch;
+            window.fetch = async (...args) => {
+                const response = await originalFetch(...args);
+
+                if (response.status === 401) {
+                    const data = await response.json();
+
+                    // Access token이 만료된 경우 처리
+                    if (data.detail === "Access token has expired.") {
+                        console.warn("Access token has expired. Attempting to refresh...");
+                        await refreshAccessToken();
+                    }
+                }
+
+                return response;
+            };
+        </script>
         <script src="{% static 'js/base.js' %}"></script>
         {% block javascript %}
         {% endblock javascript %}


### PR DESCRIPTION
+ 재발급을 위한 view 가 TokenRefreshView 의 post 를 그대로 사용하고 있었음. 
    + TokenRefreshView 는 헤더의 토큰을 확인함.
    + JWT 를 쿠키에 담아 사용하기 때문에, 재발급이 제대로 이루어지지 않음.
+ super().post() 를 제거하고 쿠키에서 refresh token 을 확인한다. 
    + TokenRefreshSerializer 를 import 하여 재발급을 진행하도록 수정했다. 